### PR TITLE
[GCI2018] Remove redundant comments from cloud-data-storage-client-poc/index.js

### DIFF
--- a/examples/cloud-data-storage-client-poc/index.js
+++ b/examples/cloud-data-storage-client-poc/index.js
@@ -11,7 +11,7 @@ gcs.interceptors.push({
       'https://www.googleapis.com',
       'http://localhost:8080'
     );
-    // console.log(JSON.stringify(reqOpts));
+   
     return reqOpts;
   },
 });
@@ -24,10 +24,6 @@ gcs
 
       const bucket = await gcs.bucket('test-bucket').get();
 
-      // this endpoint doesn't work correctly
-      // const uploadRes = await gcs.bucket('test-bucket').upload('./test.txt');
-
-      // await gcs.bucket('test-bucket').delete();
     } catch (err) {
       console.log(`${err.message}`);
     }


### PR DESCRIPTION
Remove redundant comments from `examples/cloud-data-storage-client-poc/index.js`