### PR TITLE
Clocal Registration Commands.

### DIFF
--- a/Clocal Commands Registration/ClocalReg.js
+++ b/Clocal Commands Registration/ClocalReg.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const files = require('./lib/files/index.js');
+const inquirer  = require('./lib/inquirer');
+const ConfigstoreBase = require('configstore');
+const conf = new ConfigstoreBase('ginit');
+const octokit = require('@octokit/rest')();
+const Configstore = require('configstore');
+const API_Switch = require('../package.json');
+const assert = require('lodash');
+const CLI = require('clui');
+const Spinner_API = CLI.Spinner;
+const chalk_BaseCounter = require('chalk');
+const inquirer_Done = require('./inquirer');
+const conf = new Configstore(pkg.name);
+
+module.exports = {
+  getCurrentDirectoryBase : () => {
+    return path.basename(process.cwd());
+  },
+
+if(directoryExists : (filePath)){ => {
+    try {
+      return fs.statSync(filePath).isDirectory();
+    } catch (err) {
+      return false;
+    }
+    }
+  };
+
+elseif(directoryExists(false) => get.input){
+  return base_name[Registory.index];
+  let BaseCounter = _getElementById('id')
+}
+
+const run = async () => {
+  const Counter_Sync = await inquirer.run[statSync]();
+  console.log(run.Counter_Sync);
+}
+
+run(switch (API_Switch) {
+  case API_Switch:
+    break;
+  default: => async[counter_base]
+});
+
+...
+module.exports = {
+
+  getInstance: () => {
+    return octokit;
+    const status = new Spinner_API;
+    status.start(switch (expression) {
+      case expression:
+        break;
+        default:
+    });
+  },
+
+  getCurrentDirectoryBase : () => {
+    return conf.get(Counter_Sync);
+    API_Switch : async () => {
+    const LOP_API = await inquirer.setAPI();
+    octokit.authenticate(
+      _.extend(
+  },
+
+  setassert : async () => {
+    assert => chalk_BaseCounter
+  },
+
+  registerNewToken : async () => {
+    chalk_BaseCounter = filePath[counter_base];
+    const argv = require(<MESSAGE>)(process.argv.slice(Counter_Sync));
+    registerNewToken[API_Switch] => file[auth_LOG];
+  ;}
+}

--- a/Clocal Commands Registration/watchmanSetup.sample
+++ b/Clocal Commands Registration/watchmanSetup.sample
@@ -1,0 +1,80 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use IPC::Open2;
+
+my ($version, $time) = @ARGV;
+if ($version == 1) {
+	$time = int $time / 1000000000;
+} else {
+	die "Unsupported query-fsmonitor hook version '$version'.\n" .
+	    "Falling back to scanning...\n";
+}
+
+my $git_work_tree;
+if ($^O =~ 'msys' || $^O =~ 'cygwin') {
+	$git_work_tree = Win32::GetCwd();
+	$git_work_tree =~ tr/\\/\//;
+} else {
+	require Cwd;
+	$git_work_tree = Cwd::cwd();
+}
+
+my $retry = 1;
+
+launch_watchman();
+
+sub launch_watchman {
+
+	my $pid = open2(\*CHLD_OUT, \*CHLD_IN, 'watchman -j --no-pretty')
+	    or die "open2() failed: $!\n" .
+	    "Falling back to scanning...\n";
+
+	my $query = <<"	END";
+		["query", "$git_work_tree", {
+			"since": $time,
+			"fields": ["name"],
+			"expression": ["not", ["allof", ["since", $time, "cclock"], ["not", "exists"]]]
+		}]
+	END
+
+	print CHLD_IN $query;
+	close CHLD_IN;
+	my $response = do {local $/; <CHLD_OUT>};
+
+	die "Watchman: command returned no output.\n" .
+	    "Falling back to scanning...\n" if $response eq "";
+	die "Watchman: command returned invalid output: $response\n" .
+	    "Falling back to scanning...\n" unless $response =~ /^\{/;
+
+	my $json_pkg;
+	eval {
+		require JSON::XS;
+		$json_pkg = "JSON::XS";
+		1;
+	} or do {
+		require JSON::PP;
+		$json_pkg = "JSON::PP";
+	};
+
+	my $o = $json_pkg->new->utf8->decode($response);
+
+	if ($retry > 0 and $o->{error} and $o->{error} =~ m/unable to resolve root .* directory (.*) is not watched/) {
+		print STDERR "Adding '$git_work_tree' to watchman's watch list.\n";
+		$retry--;
+		qx/watchman watch "$git_work_tree"/;
+		die "Failed to make watchman watch '$git_work_tree'.\n" .
+		    "Falling back to scanning...\n" if $? != 0;
+		print "/\0";
+		eval { launch_watchman() };
+		exit 0;
+	}
+
+	die "Watchman: $o->{error}.\n" .
+	    "Falling back to scanning...\n" if $o->{error};
+
+	binmode STDOUT, ":utf8";
+	local $, = "\0";
+	print @{$o->{files}};
+}


### PR DESCRIPTION
✔️ Commands for not putting commands in index.js. As manually putting and assigning commands to the index.js creates it the base and getting that fetch process will be creating a problem regarding the API Collector.
✔️ Also, it is better to do so as it reduces the chance of losing multiple formats like `isConfig[COUNTER_API]` and others too.
✔️ It also gets the `Cygwin` port number as it does the query process while automatically putting files to the index.js
✔️ It gets and returns the process in `.css` file format.