### PR TITLE
Add code coverage with nyc tool with HTML support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node bin/clocal-gcp",
     "dev": "nodemon bin/clocal-gcp",
-    "test": "ava",
+    "test": "nyc --reporter=html --reporter=text ava src/**/*.spec.js",
     "test-watch": "ava --watch"
   },
   "bin": {
@@ -34,6 +34,7 @@
     "@types/express": "^4.11.1",
     "@types/node": "^8.0.0",
     "ava": "1.0.0-beta.6",
-    "nodemon": "^1.17.3"
+    "nodemon": "^1.17.3",
+    "nyc": "^13.1.0"
   }
 }


### PR DESCRIPTION
### Used **nyc** tool by IstanbulJS to provide Code coverage with added functionality of HTML support (see below)-

* Employed method to generate HTML file in `./coverage` depicting Code Coverage results in both CLI format and Graphical format.

* Run the coverage command with `sudo npm test` to view the coverage details in the CLI and generate an HTML file in `./coverage`.

![CodeCoverageCommand](https://i.imgur.com/iEv97Cj.png)

* View the Graphical data by opening `./coverage/index.html` in a web browser.

![CodeCoverageBrowser](https://i.imgur.com/oL1e9LT.png)

* You can then browse the directory structure to see which files failed the tests.

![CodeCoverageDirectoryStructure](https://i.imgur.com/kMiZKf5.png)