### PR TITLE
Remove redundant require of express library

### DIFF
--- a/src/services/cloud-storage/cloud-storage.js
+++ b/src/services/cloud-storage/cloud-storage.js
@@ -5,7 +5,6 @@ const formidable = require('formidable');
 const CloudLocal = require('./cloud-local');
 const bodyParser = require('body-parser');
 const Bucket = require('./bucket');
-const express = require('express');
 
 class CloudStorage extends CloudLocal {
   init() {


### PR DESCRIPTION
In clocal-gcp cloud-storage module, cloud-storage.js file we have express require at the top, which is no longer used in this file. 