### PR TITLE
[cloud-memory-store] Remove redundant require of express library

### DIFF
--- a/src/services/cloud-memory-store/cloud-memory-store.js
+++ b/src/services/cloud-memory-store/cloud-memory-store.js
@@ -3,7 +3,6 @@
 const CloudLocal = require('./cloud-local');
 const bodyParser = require('body-parser');
 const MemoryStore = require('./memory-store');
-const express = require('express');
 
 class CloudMemoryStore extends CloudLocal {
   init() {


### PR DESCRIPTION
In clocal-gcp cloud-memory-store module, **cloud-memory-store.js** file we have express require at the top, which is no longer used in this file.