### PR TITLE
Google Code-In 2018: Update package.json for code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "node bin/clocal-gcp",
     "dev": "nodemon bin/clocal-gcp",
-    "test": "ava",
-    "test-watch": "ava --watch"
+    "test": "nyc --all ava --timeout=4000",
+    "test-watch": "ava --watch",
+    "coverage-summary": "nyc report --reporter=text-summary"
   },
   "bin": {
     "clocal-gcp": "./bin/clocal-gcp"
@@ -34,6 +35,7 @@
     "@types/express": "^4.11.1",
     "@types/node": "^8.0.0",
     "ava": "1.0.0-beta.6",
-    "nodemon": "^1.17.3"
+    "nodemon": "^1.17.3",
+    "nyc": "^13.1.0"
   }
 }


### PR DESCRIPTION
Code coverage is an important part of building applications because it checks how much source code is executed when tests and other files run. A development dependency for nyc was added to package.json, which efficiently checks code coverage depending on parameters. A command for code coverage was also added to "tests" in package.json, where the --all flag was set so that not only can you check test files but others as well. Additionally, a command for checking nyc reports was added.