### PR TITLE
Add Command Registration through Read Directory method

### DIFF
--- a/bin/clocal-gcp
+++ b/bin/clocal-gcp
@@ -3,18 +3,23 @@
 'use strict';
 
 const program = require('commander');
-
+const FunctionalArray = require('../src/serviceCounter/API')
 const commandsArray = require('../src/services/index').commands;
-
 program.version('1.0.0').description('Clocal GCP');
 
-const commandNameList = [];
-
-commandsArray.map(command => {
+let length = items.length;
+for(var i = 0; i < length;i++){
+  const ServicesCmdBash = require('../src/services/cli-commands/'+items[i]+'/cmd');
+  commandsArray = [ServicesCmdBash];
+  program.version(<Version>).description('Clocal GCP');
+  
+  const commandNameList = [FunctionalArray];
+  commandsArray.map(command => {
   commandNameList.push(command.commandName);
   program.command(command.commandName).action(command.action);
 });
-
+}
+ 
 program.command('list').action(() => {
   const commandNames = commandNameList.reduce((prev, current) => {
     return `${prev}\n${current}`;


### PR DESCRIPTION
✔️ Before using the Read Directory method, the register commands were executed by explicitly putting them in an index.js file in the services folder.

✔️ After using the given methodology, commands are executed directly without putting them in index.js file.