### PR TITLE
Add dynamic commands registering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,25 @@
 
 Emulation engine for GCP
 
-_clocal-gcp_ provides an easy-to-use test/mocking framework for developing Cloud applications.
+clocal-gcp provides an easy-to-use test/mocking framework for developing Cloud applications.
 
 Currently features are under development.
 
-# Overview
+## 🚀 Install
+
+
+```
+$ git clone https://github.com/cloudlibz/clocal-gcp.git
+
+$ cd clocal-gcp
+
+$ yarn
+
+$ yarn dev <command>
+```
+
+
+# 📚 Overview
 
 _clocal-gcp_ spins up the following core Cloud APIs on your local machine:
 
@@ -15,26 +29,3 @@ _clocal-gcp_ spins up the following core Cloud APIs on your local machine:
 * **Cloud CDN** at http://localhost:7581
 * **Cloud ENDPOINTS** at http://localhost:7567
 * **Cloud Storage** at http://localhost:7572
-
-## Developing
-
-Requirements \*
-
-* NodeJS (^8.9.4)
-* yarn (^1.6.0)
-
-```
-1.  git clone https://github.com/cloudlibz/clocal-gcp.git
-```
-
-```
-2.  cd clocal-gcp
-```
-
-```
-3.  yarn
-```
-
-```
-4.  yarn dev <command>
-```

--- a/bin/clocal-gcp
+++ b/bin/clocal-gcp
@@ -2,13 +2,20 @@
 
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const program = require('commander');
 
-const commandsArray = require('../src/services/index').commands;
+const commandsArray = [];
+const commandNameList = [];
+const commandsDirectory = path.join(__dirname, '../src/services/cli-commands');
+
+const directories = fs.readdirSync(commandsDirectory);
+directories.forEach(dir => {
+  commandsArray.push(require(path.join(commandsDirectory, dir, '/cmd.js')));
+});
 
 program.version('1.0.0').description('Clocal GCP');
-
-const commandNameList = [];
 
 commandsArray.map(command => {
   commandNameList.push(command.commandName);

--- a/src/services/cloud-memory-store/cloud-memory-store.js
+++ b/src/services/cloud-memory-store/cloud-memory-store.js
@@ -3,7 +3,6 @@
 const CloudLocal = require('./cloud-local');
 const bodyParser = require('body-parser');
 const MemoryStore = require('./memory-store');
-const express = require('express');
 
 class CloudMemoryStore extends CloudLocal {
   init() {

--- a/src/services/cloud-storage/cloud-storage.js
+++ b/src/services/cloud-storage/cloud-storage.js
@@ -5,7 +5,6 @@ const formidable = require('formidable');
 const CloudLocal = require('./cloud-local');
 const bodyParser = require('body-parser');
 const Bucket = require('./bucket');
-const express = require('express');
 
 class CloudStorage extends CloudLocal {
   init() {


### PR DESCRIPTION
## Fast Summary
This PR adds the ability to register `commander` commands dynamically using the *NodeJS fs* method called `readdir`. How does it work? It's simple - we are reading the `cli-commands` directory and then by looping through the directories we are requiring commands and then pushing it to the array of available commands. All the rest of the *bin* code stays the same.