### PR TITLE
Add Test Coverage to the Code

### DIFF
--- a/bin/Clocal Commads Registration.ts
+++ b/bin/Clocal Commads Registration.ts
@@ -1,0 +1,32 @@
+const fs              =   require('fs');
+const program         =   require('commander');
+const main            =   process.cwd() + "/src/services/cli-commands/";
+let commandsArray     =   [];
+const commandNameList =   [];
+
+program.version('1.0.0').description('Clocal GCP');
+
+fs.readdir(main, function(err, items) {
+  var totalImports = items.length
+  while (i >= totalImports) {
+
+    const required = require('../src/services/cli-commands/'+items[i]+'/cmd');
+    commandsArray = [required];
+
+    commandsArray.map(command => {
+      commandNameList.push(command.commandName);
+      program.command(command.commandName).action(command.action);
+    });
+    i++;
+  }
+
+  program.command('list').action(() => {
+    const commandNames = commandNameList.reduce((prev, current) => {
+      return `${prev}\n${current}`;
+    }, '');
+
+  console.log(commandNameList.toString());
+  });
+
+  program.parse(process.argv);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node bin/clocal-gcp",
     "dev": "nodemon bin/clocal-gcp",
     "test": "ava",
+    "test:coverage": "nyc ava ./src/**/*.spec.js",
     "test-watch": "ava --watch"
   },
   "bin": {
@@ -34,6 +35,7 @@
     "@types/express": "^4.11.1",
     "@types/node": "^8.0.0",
     "ava": "1.0.0-beta.6",
-    "nodemon": "^1.17.3"
+    "nodemon": "^1.17.3",
+    "nyc": "^13.1.0"
   }
 }


### PR DESCRIPTION
✔️ This includes the Code which is able to display test Code Coverage to the screen when running the commands.

✔️ These Commands are  `npm run test:coverage` or `yarn test:coverage`.